### PR TITLE
README - replace rocket chat with riot chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 * [Whitepaper](WHITEPAPER.md)
 * [Crowdfund Plan](PLAN.md)
 * [Faq](FAQ.md)
-* [Rocket.Chat](https://cosmos.rocket.chat/)
+* [Riot.Chat](https://riot.im/app/#/room/#cosmos:matrix.org)


### PR DESCRIPTION
In the C4YT presentation, Jae said the chat has been moved to Riot chat.  rocket chat is no longer used.