### PR TITLE
Simplify the text about IBCBlockCommitTx essence

### DIFF
--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -406,7 +406,7 @@ bidirectional stream of proof-of-existence datagrams (transactions).
 
 The IBC protocol can naturally be defined using two types of transactions: an
 `IBCBlockCommitTx` transaction, which allows a blockchain to prove to any
-observer of its most recent block-hash, and an `IBCPacketTx` transaction, which
+observer the existance of the blockchian's most recent block-hash, and an `IBCPacketTx` transaction, which
 allows a blockchain to prove to any observer that the given packet was indeed
 published by the sender's application, via a Merkle-proof to the recent
 block-hash.


### PR DESCRIPTION
Unless I'm getting it all wrong, but the fix tries to make it easier to grasp what IBCBlockCommitTx is about - it's somehow closer to the wording here: https://github.com/zmanian/gnuclear-whitepaper#inter-blockchain-communication-ibc