### PR TITLE
Remove bitcoin foundation from whitepaper

### DIFF
--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -308,7 +308,7 @@ security for nodes and light clients.
 ### Governance #################################################################
 
 Distributed public ledgers should have a constitution and a governance system.
-Bitcoin relies on the Bitcoin Foundation and mining to
+Bitcoin relies on social consensus and mining to
 coordinate upgrades, but this is a slow process.  Ethereum split into ETH and
 ETC after hard-forking to address TheDAO hack, largely because there was no
 prior social contract nor mechanism for making such decisions.


### PR DESCRIPTION
The Bitcoin Foundation effectively shut down in 2015.