### PR TITLE
Fix: fix two typos in the document

### DIFF
--- a/DEX.md
+++ b/DEX.md
@@ -82,7 +82,7 @@ cheat.
 Even "leaderless" consensus systems suffer from various forms of cheating.  For
 some systems, such as Swirld's hash-graph system, the one who has more control
 over the network, or one who has more connections to peers, has greater power
-to determine the order of transactions.  TODO: also mention other attemps.
+to determine the order of transactions.  TODO: also mention other attempts.
 
 Both problems are fundamental to the nature of distributed ledgers -- a global
 distributed ledger cannot make any final decisions (about the order of

--- a/DISCLAIMERS.md
+++ b/DISCLAIMERS.md
@@ -14,7 +14,7 @@
 Tendermint Core, bugs in the Cosmos Hub ABCI application, bugs in client or
 wallet software, etc.
 
-* There may be irreconciliable differences among atom holders that cause the
+* There may be irreconcilable differences among atom holders that cause the
   Cosmos Hub blockchain to split (hard-fork) into two or more blockchains.  This
 may cause economic harm for end-users and related services such as
 crypto-exchanges .


### PR DESCRIPTION
Two typos in the following documents are fixed:
- DEX.md
- DISCLAIMERS.md